### PR TITLE
Switch from hiccup to clostache templating

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN npm install && \
     cp -r build/* resources/ && \
     cp target/kifshare-standalone.jar .
 
+COPY ui/ui.xml resources/ui.xml
+
 RUN ln -s "/usr/bin/java" "/bin/kifshare"
 
 ENTRYPOINT ["kifshare", "-Dlogback.configurationFile=/etc/iplant/de/logging/kifshare-logging.xml", "-cp", ".:resources:kifshare-standalone.jar", "kifshare.core"]

--- a/src/kifshare/core.clj
+++ b/src/kifshare/core.clj
@@ -52,7 +52,7 @@
   (GET "/resources/css/:rsc-name"
        [rsc-name]
        (let [resource-root (ft/path-join (cfg/resources-root) (cfg/css-dir))]
-         (static-resp rsc-name :root resource-root)))
+         (resp/content-type (static-resp rsc-name :root resource-root) "text/css")))
 
   (GET "/resources/js/:rsc-name"
        [rsc-name]

--- a/src/kifshare/ui_template.clj
+++ b/src/kifshare/ui_template.clj
@@ -8,214 +8,28 @@
             [cheshire.core :as json])
   (:import [org.apache.commons.io FileUtils]))
 
-(defn clear
+(defn read-template
   []
-  (log/debug "entered kifshare.ui-template/clear")
-  (html [:div {:class "clear"}]))
+  (slurp "resources/ui.xml"))
 
-(defn section-spacer [] (html [:div {:class "section-spacer"}]))
-
-(defn irods-avu-row
-  [mmap]
-  (log/debug "entered kifshare.ui-template/irods-avu-row")
-
-  (html
-   [:tr
-    [:td {:title (:attr mmap)} (:attr mmap)]
-    [:td {:title (:value mmap)} (:value mmap)]
-    [:td {:title (:unit mmap)} (:unit mmap)]]))
-
-(defn irods-avu-table
-  [metadata]
-  (log/debug "entered kifshare.ui-template/irods-avu-table")
-
-  (if (pos? (count metadata))
-    (html
-     [:div {:id "irods-avus"}
-      [:div {:id "irods-avus-header"}
-       [:h2 "Metadata"]]
-      [:table {:id "irods-avus-data"}
-       [:thead
-        [:tr
-         [:th "Attribute"]
-         [:th "Value"]
-         [:th "Unit"]]]
-       [:tbody
-        (map irods-avu-row metadata)]]
-      (section-spacer)])))
-
-(defn lastmod
-  [ticket-info]
-  (log/debug "entered kifshare.ui-template/lastmod")
-
-  (html
-   [:div {:id "lastmod-detail"}
-    [:div {:id "lastmod-label"}
-     [:p "Last Modified:"]]
-    [:div {:id "lastmod"}
-     [:p (:lastmod ticket-info)]]]))
-
-(defn filesize
-  [ticket-info]
-  (log/debug "entered kifshare.ui-template/filesize")
-
-  (html
-   [:div {:id "size-detail"}
-    [:div {:id "size-label"}
-     [:p "File Size:"]]
-    [:div {:id "size"}
-     [:p (FileUtils/byteCountToDisplaySize
-          (Long/parseLong (:filesize ticket-info)))]]]))
+(def memo-read-template
+  (memoize read-template))
 
 (defn ui-ticket-info
   [ticket-info]
   (assoc ticket-info
     :import_template (cfg/de-import-flags)
-    :wget_template (cfg/wget-flags)
-    :curl_template (cfg/curl-flags)
-    :iget_template (cfg/iget-flags)))
-
-(defn template-map
-  [ticket-info]
-  (log/debug "entered kifshare.ui-template/template-map")
-  (html
-   [:span {:id "ticket-info" :style "display: none;"}
-    [:div {:id "ticket-info-map"}
-     (json/generate-string
-      (ui-ticket-info ticket-info))]]))
-
-(defn input-display
-  [id]
-  (log/debug "entered kifshare.ui-template/input-display")
-
-  (html
-   #_[:div {:id id}]
-   [:input
-    {:id id
-     :type "text"
-     :readonly false
-     :value ""}]))
-
-(defn irods-instr
-  [ticket-info]
-  (log/debug "entered kifshare.ui-template/irods-instr")
-
-  (html
-   [:div {:id "irods-instructions"}
-    [:div {:id "irods-instructions-label"}
-     [:h2 {:title "iRODS icommands"}
-      [:a {:href (cfg/irods-url)} "iRODS icommands"] ":"]]
-    [:div {:id "clippy-irods-instructions"}
-     (input-display "irods-command-line")
-     [:span {:title "copy to clipboard"}
-      [:button {:id "clippy-irods-wrapper"
-                :class "clippy-irods"
-                :title "Copy"}
-       "Copy"]]]]))
-
-(defn de-import-instr
-  [ticket-info]
-  (log/debug "entered kifshare.ui-template/de-import-instr")
-
-  (html
-   [:div {:id "de-import-instructions"}
-    [:div {:id "de-import-instructions-label"}
-     [:h2 {:title "Discovery Environment Import URL"}
-      [:a {:href (cfg/de-url)} "DE Import URL"] ":"]]
-    [:div {:id "clippy-import-instructions"}
-     (input-display "de-import-url")
-     [:span {:title "copy to clipboard"}
-      [:button {:id "clippy-import-wrapper"
-                :class "clippy-import"
-                :title "Copy"}
-       "Copy"]]]]))
-
-(defn downloader-instr
-  [ticket-id ticket-info]
-  (log/debug "entered kifshare.ui-template/downloader-instr")
-
-  (html
-   [:div {:id "wget-instructions"}
-    [:div {:id "wget-instructions-label"}
-     [:p "Wget:"]]
-    [:div {:id "clippy-wget-instructions"}
-     (input-display "wget-command-line")
-     [:span  {:title "copy to clipboard"}
-      [:button {:id "clippy-wget-wrapper"
-                :class "clippy-wget"
-                :title "Copy"}
-       "Copy"]]]]
-
-   [:div {:id "curl-instructions"}
-    [:div {:id "curl-instructions-label"}
-     [:p "cURL:"]]
-    [:div {:id "clippy-curl-instructions"}
-     (input-display "curl-command-line")
-     [:span {:title "copy to clipboard"}
-      [:button {:id "clippy-curl-wrapper"
-                :class "clippy-curl"
-                :title "Copy"}
-       "Copy"]]]]))
-
-(defn menu
-  [ticket-info]
-  (html
-   [:div {:id "menu"}
-    [:ul
-     [:li [:div {:id "logo-container"}
-           [:img {:id "logo" :src (cfg/logo-path)}]]]
-     [:li [:div [:h1 {:id "filename"
-                      :title (:filename ticket-info)}
-                 (:filename ticket-info)]]]
-     [:li [:div {:id "download-container"}
-           [:a {:href (str "d/" (:ticket-id ticket-info) "/" (:filename ticket-info))
-                :id "download-link"}
-            [:div {:id "download-link-area"}
-             "Download!"]]]]]]))
-
-(defn details
-  [ticket-info]
-  [:div {:id "details"}
-   [:a {:name "details-section"}]
-   [:div {:id "details-header"}
-    [:h2 "File Details"]]
-   (lastmod ticket-info)
-   (filesize ticket-info)
-   (section-spacer)])
-
-(defn alt-downloads
-  [ticket-info]
-  (log/debug "entered kifshare.ui-template/alt-downloads")
-
-  (html
-   [:div {:id "alt-downloads-header"}
-    [:h2 "Alternative Download Methods"]]
-   [:div {:id "alt-downloads"}
-    (de-import-instr ticket-info)
-    (irods-instr ticket-info)
-    (downloader-instr (:ticket-id ticket-info) ticket-info)
-    (section-spacer)]))
-
-(defn footer
-  []
-  (html
-   [:div {:id "footer"}
-    [:p (cfg/footer-text)]]))
+    :wget_template   (cfg/wget-flags)
+    :curl_template   (cfg/curl-flags)
+    :iget_template   (cfg/iget-flags)))
 
 (defn landing-page
   [ticket-id metadata ticket-info]
   (log/debug "entered kifshare.ui-template/landing-page")
-
-  (html
-   [:head
-    [:title (:filename ticket-info)]
-    (map include-css (cfg/css-files))
-    (map include-js (cfg/javascript-files))]
-   [:body
-    (template-map ticket-info)
-    (menu ticket-info)
-    [:div#wrapper {:id "page-wrapper" :class "container_12"}
-     (details ticket-info)
-     (alt-downloads ticket-info)
-     (irods-avu-table metadata)
-     (footer)]]))
+  (prs/render (memo-read-template)
+              (assoc ticket-info
+                     :metadata metadata
+                     :filesize (FileUtils/byteCountToDisplaySize
+                                (Long/parseLong (:filesize ticket-info)))
+                     :ticket-info-json (json/generate-string
+                                        (ui-ticket-info ticket-info)))))

--- a/src/kifshare/ui_template.clj
+++ b/src/kifshare/ui_template.clj
@@ -1,7 +1,4 @@
 (ns kifshare.ui-template
-  (:use [hiccup.core]
-        [hiccup.page :only [include-css include-js html5]]
-        [kifshare.common :only [layout]])
   (:require [kifshare.config :as cfg]
             [clostache.parser :as prs]
             [clojure.tools.logging :as log]

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -1,11 +1,11 @@
 <html>
   <head>
     <title>{{{filename}}}</title>
-    <link href="resources/css/reset.css" rel="stylesheet" type="text/css">
-    <link href="resources/css/960.css" rel="stylesheet" type="text/css">
-    <link href="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/css/jquery.dataTables.css" rel="stylesheet" type="text/css">
-    <link href="resources/css/jquery-ui-1.8.21.custom.css" rel="stylesheet" type="text/css">
-    <link href="resources/css/kif.css" rel="stylesheet" type="text/css">
+    <link href="resources/css/reset.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/960.css" rel="stylesheet" type="text/css" />
+    <link href="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/css/jquery.dataTables.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/jquery-ui-1.8.21.custom.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/kif.css" rel="stylesheet" type="text/css" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/jquery.dataTables.min.js" type="text/javascript"></script>
@@ -18,6 +18,10 @@
   </head>
 
   <body>
+    <span id="ticket-info" style="display: none">
+      <div id="ticket-info-map">{{{ticket-info-json}}}</div>
+    </span>
+
     <div id="menu">
       <ul>
         <li>
@@ -81,7 +85,7 @@
         <div id="de-import-instructions">
           <div id="de-import-instructions-label">
             <h2 title="Discovery Environment Import URL">
-              <a href="{{{de-url}}}">DE Import URL</a> ":"
+              <a href="{{{de-url}}}">DE Import URL:</a>
             </h2>
           </div>
 
@@ -96,7 +100,7 @@
         <div id="irods-instructions">
           <div id="irods-instructions-label">
             <h2 title="IRODS icommands">
-              <a href="{{{irods-url}}}">iRODS icommands</a> ":"
+              <a href="{{{irods-url}}}">iRODS icommands:</a>
             </h2>
           </div>
 

--- a/ui/ui.xml
+++ b/ui/ui.xml
@@ -1,0 +1,174 @@
+<html>
+  <head>
+    <title>{{{filename}}}</title>
+    <link href="resources/css/reset.css" rel="stylesheet" type="text/css">
+    <link href="resources/css/960.css" rel="stylesheet" type="text/css">
+    <link href="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/css/jquery.dataTables.css" rel="stylesheet" type="text/css">
+    <link href="resources/css/jquery-ui-1.8.21.custom.css" rel="stylesheet" type="text/css">
+    <link href="resources/css/kif.css" rel="stylesheet" type="text/css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js" type="text/javascript"></script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/jquery.dataTables.min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.0/mustache.min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.2/underscore-min.js" type="text/javascript"></script>
+    <script src="resources/js/jquery.tooltip.min.js" type="text/javascript"></script>
+    <script src="resources/js/jquery.zclip.min.js" type="text/javascript"></script>
+    <script src="resources/js/json2.js" type="text/javascript"></script>
+    <script src="resources/js/kif.js" type="text/javascript"></script>
+  </head>
+
+  <body>
+    <div id="menu">
+      <ul>
+        <li>
+          <div id="logo-container">
+            <img id="logo" src="resources/img/cyverse-logo-small.png">
+          </div>
+        </li>
+        <li>
+          <div>
+            <h1 id="filename" title="{{{filename}}}">{{{filename}}}</h1>
+          </div>
+        </li>
+        <li>
+          <div>
+            <a href="d/{{ticket-id}}/{{filename}}">
+              <div id="download-link-area">Download!</div>
+            </a>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div class="container_12" id="page-wrapper">
+      <div id="details">
+        <a name="details-section"></a>
+
+        <div id="details-header">
+          <h2>File Details</h2>
+        </div>
+
+        <div id="lastmod-detail">
+          <div id="lastmod-label">
+            <p>Last Modified:</p>
+          </div>
+
+          <div id="lastmod">
+            {{{lastmod}}}
+          </div>
+        </div>
+
+        <div id="size-detail">
+          <div id="size-label">
+            <p>File Size:</p>
+          </div>
+
+          <div id="size">
+            {{{filesize}}}
+          </div>
+        </div>
+
+        <div class="section-spacer"></div>
+      </div>
+
+
+
+      <div id="alt-downloads">
+        <div id="alt-downloads-header">
+          <h2>Alternative Download Methods</h2>
+        </div>
+
+        <div id="de-import-instructions">
+          <div id="de-import-instructions-label">
+            <h2 title="Discovery Environment Import URL">
+              <a href="{{{de-url}}}">DE Import URL</a> ":"
+            </h2>
+          </div>
+
+          <div id="clippy-import-instructions">
+            <input id="de-import-url" type="text" readonly="false" value>
+            <span title="copy to clipboard">
+              <button id="clippy-import-wrapper" class="clippy-import" title="Copy">Copy</button>
+            </span>
+          </div>
+        </div>
+
+        <div id="irods-instructions">
+          <div id="irods-instructions-label">
+            <h2 title="IRODS icommands">
+              <a href="{{{irods-url}}}">iRODS icommands</a> ":"
+            </h2>
+          </div>
+
+          <div id="clippy-irods-instructions">
+            <input id="irods-command-line" type="text" readonly="false" value>
+            <span title="copy to clipboard">
+              <button id="clippy-irods-wrapper" class="clippy-irods" title="Copy">Copy</button>
+            </span>
+          </div>
+        </div>
+
+        <div id="wget-instructions">
+          <div id="wget-instructions-label">
+            <p>Wget:</p>
+          </div>
+
+          <div id="clippy-wget-instructions">
+            <input id="wget-command-line" type="text" readonly="false" value>
+            <span title="copy to clipboard">
+              <button id="clippy-wget-wrapper" class="clippy-wget" title="Copy">Copy</button>
+            </span>
+          </div>
+        </div>
+
+        <div id="curl-instructions">
+          <div id="curl-instructions-label">
+            <p>cURL:</p>
+          </div>
+
+          <div id="clippy-curl-instructions">
+            <input id="curl-command-line" type="text" readonly="false" value>
+            <span title="copy to clipboard">
+              <button id="clippy-curl-wrapper" class="clippy-curl" title="Copy">Copy</button>
+            </span>
+          </div>
+        </div>
+
+        <div class="section-spacer"></div>
+      </div>
+
+      <div id="irods-avus">
+        <div id="irods-avus-header">
+          <h2>Metadata</h2>
+        </div>
+
+        <table id="irods-avus-data">
+          <thead>
+            <tr>
+              <th>Attribute</th>
+              <th>Value</th>
+              <th>Unit</th>
+            </tr>
+          </thead>
+          <tbody>
+          {{#metadata}}
+            <tr>
+              <td title="{{attr}}">{{attr}}</td>
+              <td title="{{value}}">{{value}}</td>
+              <td title="{{unit}}">{{unit}}</td>
+            </tr>
+          {{/metadata}}
+          </tbody>
+        </table>
+
+        <div class="section-spacer"></div>
+      </div>
+
+      <div id="footer">
+        <p>
+          CyVerse is funded by a grant from the National Science Foundation Plant Science Cyberinfrastructure Collaborative (#DBI-0735191, #DBI-1265383).
+        </p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Using Clostache to templatize the download pages instead of generating them with hiccup will make future changes to kifshare's ui a bit easier to accomplish. This should not change anything major in the appearance of the UI and should not affect performance.