### PR TITLE
Improve kifshare's first-byte time with a streamed response

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
               expand: true,
               flatten: true,
               cwd: 'ui',
-              src: ['ui.xml'],
+              src: ['*.xml'],
               dest: 'resources/'
             }
         ]

--- a/project.clj
+++ b/project.clj
@@ -54,4 +54,5 @@
             [test2junit "1.2.2"]
             [lein-ring "0.7.5"]]
 
-  :main ^:skip-aot kifshare.core)
+  :main ^:skip-aot kifshare.core
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/kifshare-logging.xml"])

--- a/src/kifshare/controllers.clj
+++ b/src/kifshare/controllers.clj
@@ -23,12 +23,12 @@
 (defn show-landing-page
   "Handles error checking and decides whether to show the
    landing page or an error page."
-  [cm ticket-id ticket-info]
+  [cm ticket-id ticket-info-promise]
   (log/debug "entered kifshare.controllers/show-landing-page")
   (landing-page
    ticket-id
-   (object-metadata cm (tickets/ticket-abs-path cm ticket-id))
-   ticket-info))
+   (future (object-metadata cm (tickets/ticket-abs-path cm ticket-id)))
+   ticket-info-promise))
 
 (defn error-map-response
   [request err-map]
@@ -45,8 +45,7 @@
     (try+
      (tickets/check-ticket cm ticket-id)
 
-     (let [ticket-info (tickets/ticket-info cm ticket-id)]
-       (log/debug "Ticket Info:\n" ticket-info)
+     (let [ticket-info (future (tickets/ticket-info cm ticket-id))]
        {:status 200 :body (show-landing-page cm ticket-id ticket-info)})
 
      (catch error? err

--- a/src/kifshare/ui_template.clj
+++ b/src/kifshare/ui_template.clj
@@ -1,16 +1,23 @@
 (ns kifshare.ui-template
   (:require [kifshare.config :as cfg]
             [clostache.parser :as prs]
+            [clojure.java.io :as io]
             [clojure.tools.logging :as log]
-            [cheshire.core :as json])
+            [cheshire.core :as json]
+            [ring.util.io :as ring-io])
   (:import [org.apache.commons.io FileUtils]))
 
-(def tmpl (ref ""))
+(def headtmpl (ref ""))
+(defn read-head-template []
+  (dosync (ref-set headtmpl (slurp "resources/head.xml"))))
 
-(defn read-template
-  []
-  (dosync
-    (ref-set tmpl (slurp "resources/ui.xml"))))
+(def pre-avustmpl (ref ""))
+(defn read-pre-avus-template []
+  (dosync (ref-set pre-avustmpl (slurp "resources/pre-avus.xml"))))
+
+(def avus-and-footertmpl (ref ""))
+(defn read-avus-and-footer-template []
+  (dosync (ref-set avus-and-footertmpl (slurp "resources/avus-and-footer.xml"))))
 
 (defn ui-ticket-info
   [ticket-info]
@@ -21,14 +28,22 @@
     :iget_template   (cfg/iget-flags)))
 
 (defn landing-page
-  [ticket-id metadata ticket-info]
+  [ticket-id metadata-promise ticket-info-promise]
   (log/debug "entered kifshare.ui-template/landing-page")
-  (prs/render @tmpl
-              (assoc ticket-info
-                     :metadata metadata
-                     :filesize (FileUtils/byteCountToDisplaySize
-                                (Long/parseLong (:filesize ticket-info)))
-                     :irods-url (cfg/irods-url)
-                     :de-url (cfg/de-url)
-                     :ticket-info-json (json/generate-string
-                                        (ui-ticket-info ticket-info)))))
+  (ring-io/piped-input-stream
+    (fn [ostream] (with-open [writer (io/make-writer ostream {})]
+      (.write writer (prs/render @headtmpl))
+      (.flush writer)
+      (let [base-info @ticket-info-promise
+            ticket-info (assoc @ticket-info-promise
+                               :filesize (FileUtils/byteCountToDisplaySize
+                                          (Long/parseLong (:filesize base-info)))
+                               :irods-url (cfg/irods-url)
+                               :de-url (cfg/de-url)
+                               :ticket-info-json (json/generate-string
+                                                  (ui-ticket-info base-info)))]
+        (.write writer (prs/render @pre-avustmpl ticket-info))
+        (.flush writer)
+        (.write writer (prs/render @avus-and-footertmpl (assoc ticket-info
+                                                                 :metadata @metadata-promise)))
+        (.flush writer))))))

--- a/ui/avus-and-footer.xml
+++ b/ui/avus-and-footer.xml
@@ -1,0 +1,35 @@
+      <div id="irods-avus">
+        <div id="irods-avus-header" class="grid_12 section-header">
+          <h2>Metadata</h2>
+        </div>
+
+        <table id="irods-avus-data">
+          <thead>
+            <tr>
+              <th>Attribute</th>
+              <th>Value</th>
+              <th>Unit</th>
+            </tr>
+          </thead>
+          <tbody>
+          {{#metadata}}
+            <tr>
+              <td title="{{attr}}">{{attr}}</td>
+              <td title="{{value}}">{{value}}</td>
+              <td title="{{unit}}">{{unit}}</td>
+            </tr>
+          {{/metadata}}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="section-spacer"></div>
+
+      <div id="footer">
+        <p>
+          CyVerse is funded by a grant from the National Science Foundation Plant Science Cyberinfrastructure Collaborative (#DBI-0735191, #DBI-1265383).
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/ui/head.xml
+++ b/ui/head.xml
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <link href="resources/css/reset.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/960.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/balloon.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/css/jquery.dataTables.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/jquery-ui-1.8.21.custom.css" rel="stylesheet" type="text/css" />
+    <link href="resources/fa/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
+    <link href="resources/css/kif.css" rel="stylesheet" type="text/css" />

--- a/ui/pre-avus.xml
+++ b/ui/pre-avus.xml
@@ -1,20 +1,4 @@
-<html>
-  <head>
     <title>{{{filename}}}</title>
-    <link href="resources/css/reset.css" rel="stylesheet" type="text/css" />
-    <link href="resources/css/960.css" rel="stylesheet" type="text/css" />
-    <link href="resources/css/balloon.min.css" rel="stylesheet" type="text/css" />
-    <link href="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/css/jquery.dataTables.css" rel="stylesheet" type="text/css" />
-    <link href="resources/css/jquery-ui-1.8.21.custom.css" rel="stylesheet" type="text/css" />
-    <link href="resources/fa/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
-    <link href="resources/css/kif.css" rel="stylesheet" type="text/css" />
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js" type="text/javascript"></script>
-    <script src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/jquery.dataTables.min.js" type="text/javascript"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.0/mustache.min.js" type="text/javascript"></script>
-    <script src="resources/js/jquery.tooltip.min.js" type="text/javascript"></script>
-    <script src="resources/js/json2.js" type="text/javascript"></script>
-    <script src="resources/js/kif.js" type="text/javascript"></script>
   </head>
 
   <body>
@@ -122,40 +106,12 @@
         <i class="fa fa-files-o"></i>
       </div>
 
-      <div class="section-spacer"></div>
-
-      <div id="irods-avus">
-        <div id="irods-avus-header" class="grid_12 section-header">
-          <h2>Metadata</h2>
-        </div>
-
-        <table id="irods-avus-data">
-          <thead>
-            <tr>
-              <th>Attribute</th>
-              <th>Value</th>
-              <th>Unit</th>
-            </tr>
-          </thead>
-          <tbody>
-          {{#metadata}}
-            <tr>
-              <td title="{{attr}}">{{attr}}</td>
-              <td title="{{value}}">{{value}}</td>
-              <td title="{{unit}}">{{unit}}</td>
-            </tr>
-          {{/metadata}}
-          </tbody>
-        </table>
-      </div>
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
+      <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js" type="text/javascript"></script>
+      <script src="https://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.8.2/jquery.dataTables.min.js" type="text/javascript"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.0/mustache.min.js" type="text/javascript"></script>
+      <script src="resources/js/jquery.tooltip.min.js" type="text/javascript"></script>
+      <script src="resources/js/json2.js" type="text/javascript"></script>
+      <script src="resources/js/kif.js" type="text/javascript"></script>
 
       <div class="section-spacer"></div>
-
-      <div id="footer">
-        <p>
-          CyVerse is funded by a grant from the National Science Foundation Plant Science Cyberinfrastructure Collaborative (#DBI-0735191, #DBI-1265383).
-        </p>
-      </div>
-    </div>
-  </body>
-</html>

--- a/ui/src/js/kif.js
+++ b/ui/src/js/kif.js
@@ -46,24 +46,22 @@
         });
     }
 
-    $(document).ready(function() {
-        var ticket_info = get_ticket_info(),
-            last_mod_date = new Date(Number($('#lastmod').text())),
-            wget_template = ticket_info.wget_template,
-            curl_template = ticket_info.curl_template,
-            iget_template = ticket_info.iget_template,
-            wget_command = htmlDecode(Mustache.render(wget_template, ticket_info)),
-            curl_command = htmlDecode(Mustache.render(curl_template, ticket_info)),
-            iget_command = htmlDecode(Mustache.render(iget_template, ticket_info));
+    var ticket_info = get_ticket_info(),
+        last_mod_date = new Date(Number($('#lastmod').text())),
+        wget_template = ticket_info.wget_template,
+        curl_template = ticket_info.curl_template,
+        iget_template = ticket_info.iget_template,
+        wget_command = htmlDecode(Mustache.render(wget_template, ticket_info)),
+        curl_command = htmlDecode(Mustache.render(curl_template, ticket_info)),
+        iget_command = htmlDecode(Mustache.render(iget_template, ticket_info));
 
-        $('#lastmod').text(last_mod_date.toString());
-        $('#irods-command-line').val(iget_command);
-        $('#curl-command-line').val(curl_command);
-        $('#wget-command-line').val(wget_command);
+    $('#lastmod').text(last_mod_date.toString());
+    $('#irods-command-line').val(iget_command);
+    $('#curl-command-line').val(curl_command);
+    $('#wget-command-line').val(wget_command);
 
-        enableCopy('irods-copy', 'irods-command-line');
-        enableCopy('curl-copy', 'curl-command-line');
-        enableCopy('wget-copy', 'wget-command-line');
-    });
+    enableCopy('irods-copy', 'irods-command-line');
+    enableCopy('curl-copy', 'curl-command-line');
+    enableCopy('wget-copy', 'wget-command-line');
 
 }());


### PR DESCRIPTION
I wanted to experiment with streaming a response using ring/jetty, and given the push to make kifshare snappy this seemed like the place to do it (plus, it's pretty much the only semi-conventional kind of "deliver webpage to browser" project we currently have). I'm not completely sure if this is worth the effort, but I figured I should put it up to see what others think.

Here's the things I did:

* Partition template into three parts: requiring only an existence
  check, requiring only basic info, and the footer needing metadata
* Load these in sequence and return them to a writer, so they can be
  delivered immediately
* Reduce buffer size for jetty so it will return these values quickly
* Move javascript lower in the file, but only in the second template (where
  it's needed), and enable it to execute immediately since at this new
  location in the file it can count on the things it needs being
  in-place

I tested this by adding in a giant sleep between various bits to see what loaded when. Even if the metadata takes ages to load, now, the rest of the page is completely usable. The upper parts of the page should appear a bit faster as well.