### PR TITLE
CORE-8529: add anonymous-file access code to kifshare

### DIFF
--- a/src/kifshare/anon_controllers.clj
+++ b/src/kifshare/anon_controllers.clj
@@ -1,0 +1,35 @@
+(ns kifshare.anon-controllers
+  (:use [kifshare.config :only [jargon-config irods-anonymous-user]]
+        [clojure-commons.error-codes])
+  (:require [kifshare.ranges :as ranges]
+            [cheshire.core :as cheshire]
+            [clojure.tools.logging :as log]
+            [clj-jargon.init :as jinit]
+            [clj-jargon.item-info :as info]
+            [clj-jargon.permissions :as perms]
+            [kifshare.errors :as errors]))
+
+(defn- validation-info
+  [cm filepath]
+  (log/info "Validating anonymous access to" filepath)
+  (cond
+    (not (info/exists? cm filepath))
+    :not-exists
+
+    (not (info/is-file? cm filepath))
+    :not-file
+
+    (not (perms/is-readable? cm (irods-anonymous-user) filepath))
+    :not-readable
+
+    :else :ok))
+
+(defn handle-options
+  [filepath]
+  (jinit/with-jargon (jargon-config) [cm]
+    (case (validation-info cm filepath)
+      :not-exists   {:status 404 :body (cheshire/encode {:error_code ERR_NOT_FOUND :message "Path not found."})}
+      :not-file     {:status 403 :body (cheshire/encode {:error_code ERR_NOT_A_FILE :message "Path not a file."})}
+      :not-readable {:status 403 :body (cheshire/encode {:error_code ERR_NOT_READABLE :message "Path not readable."})}
+      :ok           (ranges/options-resp)
+      {:status 500 :body (cheshire/encode (unchecked {:message "Unknown file status."}))})))

--- a/src/kifshare/config.clj
+++ b/src/kifshare/config.clj
@@ -141,6 +141,10 @@
   []
   (or (get @props "kifshare.irods.defaultResource") ""))
 
+(defn irods-anonymous-user
+  []
+  (or (get @props "kifshare.irods.anon-user") "anonymous"))
+
 (defn amqp-uri
   []
   (or (get @props "kifshare.amqp.uri") "amqp://guest:guest@rabbit:5672/"))

--- a/src/kifshare/core.clj
+++ b/src/kifshare/core.clj
@@ -106,7 +106,7 @@
 
 (defn- anon-files-routes []
   (context "/anon-files" []
-    (HEAD ":filepath{.*}" [filepath] nil)
+    (HEAD ":filepath{.*}" [filepath] (a-c/handle-head filepath))
     (GET ":filepath{.*}" [filepath] nil)
     (OPTIONS ":filepath{.*}" [filepath] (a-c/handle-options filepath))))
 

--- a/src/kifshare/core.clj
+++ b/src/kifshare/core.clj
@@ -107,7 +107,7 @@
 (defn- anon-files-routes []
   (context "/anon-files" []
     (HEAD ":filepath{.*}" [filepath] (a-c/handle-head filepath))
-    (GET ":filepath{.*}" [filepath] nil)
+    (GET ":filepath{.*}" [filepath :as req] (a-c/handle-get filepath req))
     (OPTIONS ":filepath{.*}" [filepath] (a-c/handle-options filepath))))
 
 (defroutes kifshare-routes

--- a/src/kifshare/core.clj
+++ b/src/kifshare/core.clj
@@ -14,6 +14,7 @@
             [ring.util.http-response :as http-resp]
             [kifshare.config :as cfg]
             [kifshare.tickets-controllers :as t-c]
+            [kifshare.anon-controllers :as a-c]
             [kifshare.amqp :as amqp]
             [kifshare.events :as events]
             [kifshare.ui-template :as ui]
@@ -105,9 +106,9 @@
 
 (defn- anon-files-routes []
   (context "/anon-files" []
-    (HEAD "/*" [:as req] nil)
-    (GET "/*" [:as req] nil)
-    (OPTIONS "/*" [:as req] nil)))
+    (HEAD ":filepath{.*}" [filepath] nil)
+    (GET ":filepath{.*}" [filepath] nil)
+    (OPTIONS ":filepath{.*}" [filepath] (a-c/handle-options filepath))))
 
 (defroutes kifshare-routes
   (GET "/" [:as {{expecting :expecting} :params :as req}]

--- a/src/kifshare/core.clj
+++ b/src/kifshare/core.clj
@@ -103,6 +103,12 @@
     (GET "/:ticket-id" [ticket-id :as request]
          (resp/content-type (t-c/get-ticket ticket-id request) "text/html; charset=utf-8"))))
 
+(defn- anon-files-routes []
+  (context "/anon-files" []
+    (HEAD "/*" [:as req] nil)
+    (GET "/*" [:as req] nil)
+    (OPTIONS "/*" [:as req] nil)))
+
 (defroutes kifshare-routes
   (GET "/" [:as {{expecting :expecting} :params :as req}]
        (if (and expecting (not= expecting "kifshare"))
@@ -117,6 +123,9 @@
 
   ;; tickets
   (ticket-routes)
+
+  ;; anonymous access
+  (anon-files-routes)
 
   (route/not-found "Not found!"))
 

--- a/src/kifshare/ranges.clj
+++ b/src/kifshare/ranges.clj
@@ -71,12 +71,12 @@
 
 (defn download-byte-range
   "Returns a response map containing a byte range from a file. Assumes validation has already been performed."
-  [cm filename filesize start-byte end-byte]
+  [cm path filesize start-byte end-byte]
   (log/debug "entered kifshare.ranges/download-byte-range")
 
   (if (or (> start-byte end-byte)
           (>= start-byte filesize))
     (unsatisfiable-resp filesize)
     (do
-      (log/warn "Download file range:" start-byte "-" end-byte "for file" filename)
-      (range-resp (chunk-stream cm filename start-byte end-byte) filesize start-byte end-byte))))
+      (log/warn "Download file range:" start-byte "-" end-byte "for file" path)
+      (range-resp (chunk-stream cm path start-byte end-byte) filesize start-byte end-byte))))

--- a/src/kifshare/ranges.clj
+++ b/src/kifshare/ranges.clj
@@ -61,6 +61,13 @@
    :headers {"Content-Range" (str "bytes */" filesize)
              "Accept-Ranges" "bytes"}})
 
+(defn non-range-resp
+  [body filename filesize & {:keys [attachment] :or {attachment false}}]
+  {:status  200
+   :body    body
+   :headers {"Content-Length"      (str filesize)
+             "Content-Disposition" (str (if attachment "attachment; " "") "filename=\"" filename "\"")}})
+
 (defn range-resp
   [body filesize start-byte end-byte]
   {:status 206

--- a/src/kifshare/ranges.clj
+++ b/src/kifshare/ranges.clj
@@ -1,0 +1,40 @@
+(ns kifshare.ranges)
+
+(defn range-request?
+  [ring-request]
+  (and (contains? ring-request :headers)
+       (contains? (:headers ring-request) "range")))
+
+;; begins with bytes=; then a start-end range (where excluding either number works, but not both)
+;; regex lookahead/lookbehind to ensure only one number is missing, not both
+(def ^:private range-regex #"\s*(bytes)\s*=\s*([0-9]+|(?=-\d))\-([0-9]+|(?<=\d-))\s*")
+
+(defn valid-range?
+  [ring-request]
+  (re-matches range-regex (get-in ring-request [:headers "range"])))
+
+(defn- longify
+  "Turn the argument to a long if it's relatively easy to do so (integral numbers and strings)"
+  [str-long]
+  (if (integer? str-long)
+    (long str-long)
+    (Long/parseLong str-long)))
+
+(defn extract-range
+  "Extract start and end bytes from the Range header"
+  [ring-request filesize]
+  (let [range-header  (get-in ring-request [:headers "range"])
+        range-matches (re-matches range-regex range-header)
+        last-byte     (- (longify filesize) 1)
+        start?        (seq (nth range-matches 2))
+        end?          (seq (nth range-matches 3))
+        ;; "N-" means N-EOF; "-M" means (EOF-M)-EOF, so:
+        ;; Start is as specified, or specified number of bytes returned (i.e. filesize - specified)
+        ;; End is as specified only if both are specified, otherwise last byte
+        start         (if start?
+                        (longify (nth range-matches 2))
+                        (- (longify filesize) (longify (nth range-matches 3))))
+        end           (if (and end? start?)
+                        (longify (nth range-matches 3))
+                        last-byte)]
+    [(max 0 start) (min end last-byte)]))

--- a/src/kifshare/tickets.clj
+++ b/src/kifshare/tickets.clj
@@ -67,9 +67,7 @@
 
   (let [ti (ticket-info cm ticket-id)]
     (log/warn "Dowloading file associated with ticket " ticket-id)
-    (assoc-in
-     {:status 200 :body (jtickets/ticket-proxy-input-stream cm (username) ticket-id)}
-     [:headers "Content-Disposition"] (str "attachment; filename=\"" (:filename ti)  "\""))))
+    (ranges/non-range-resp (jtickets/ticket-proxy-input-stream cm (username) ticket-id) (:filename ti) (Long/parseLong (:filesize ti)) :attachment true)))
 
 (defn download-byte-range
   "Returns a response map containing a byte range from a file. Assumes check-ticket has been called already, probably by ticket-info"

--- a/src/kifshare/tickets_controllers.clj
+++ b/src/kifshare/tickets_controllers.clj
@@ -108,15 +108,10 @@
   [ticket-id]
   (jinit/with-jargon (jargon-config) [cm]
     (let [ticket-info (tickets/ticket-info cm ticket-id)]
-      {:status  200
-       :headers {"Content-Length"      (str (:filesize ticket-info))
-                 "Content-Disposition" (str "filename=\"" (:filename ticket-info) "\"")
-                 "Accept-Ranges"       "bytes"}})))
+      (ranges/head-resp (:filename ticket-info) (:filesize ticket-info)))))
 
 (defn file-options
   [ticket-id]
   (jinit/with-jargon (jargon-config) [cm]
     (let [ticket-info (tickets/ticket-info cm ticket-id)]
-      {:status  200
-       :headers {"Accept-Ranges"       "bytes"
-                 "Allow"               "GET, HEAD"}})))
+      (ranges/options-resp))))


### PR DESCRIPTION
This is the main bit of the "merge anon-files into kifshare" task. There's a few changes that come with this, mostly in weird headers stuff. anon-files was previously setting:

* Accept-Ranges (no matter what -- doesn't really make sense on a non-range GET, so now it's just on head/options and actual range GETs.
* `Cache-Control: no-cache`: not sure we were getting anything out of this
* `ETag` of "W/<last modified date>": again, not sure if useful
* `Expires: 0`: same
* `Vary: *`: same
* `Content-Location: <full path>`: no idea if anyone uses this, probably not useful

In addition, the new code sets `Content-Disposition` on the anon-files responses, but without `attachment` (so it shouldn't force downloads, which is how it worked before).

If some of these are needed they can be added back, at which point I'd probably also add them to the ticket-related code. No good reason to have them different on those counts, I think.

I'll leave some comments among the code below.