### PR TITLE
Update Clojure and npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "grunt-contrib-uglify": "~5.2.2",
         "grunt-jslint": "~1.2.0",
         "grunt-shell": "~4.0.0",
-        "less": "~4.5"
+        "less": "~4.6"
       }
     },
     "node_modules/abbrev": {
@@ -174,13 +174,16 @@
       "license": "MIT"
     },
     "node_modules/copy-anything": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
-      "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-what": "^3.14.1"
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
@@ -1164,11 +1167,17 @@
       }
     },
     "node_modules/is-what": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -1248,22 +1257,20 @@
       }
     },
     "node_modules/less": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.5.1.tgz",
-      "integrity": "sha512-UKgI3/KON4u6ngSsnDADsUERqhZknsVZbnuzlRZXLQCmfC/MDld42fTydUE9B+Mla1AL6SJ/Pp6SlEFi/AVGfw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
+      "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "copy-anything": "^2.0.1",
-        "parse-node-version": "^1.0.1",
-        "tslib": "^2.3.0"
+        "copy-anything": "^3.0.5",
+        "parse-node-version": "^1.0.1"
       },
       "bin": {
         "lessc": "bin/lessc"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "errno": "^0.1.1",
@@ -1893,13 +1900,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~1.6.2",
-    "less": "~4.5",
+    "less": "~4.6",
     "grunt-contrib-less": "~3.0",
     "grunt-contrib-copy": "~1.0",
     "grunt-contrib-uglify": "~5.2.2",

--- a/project.clj
+++ b/project.clj
@@ -17,9 +17,9 @@
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "kifshare-standalone.jar"
 
-  :dependencies [[org.clojure/clojure "1.12.4"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
                  [org.clojure/tools.logging "1.3.1"]
-                 [ch.qos.logback/logback-classic "1.5.24"]
+                 [ch.qos.logback/logback-classic "1.5.32"]
                  [net.logstash.logback/logstash-logback-encoder "9.0"]
                  [hawk "0.2.11"]
                  [hiccup "2.0.0"]
@@ -28,15 +28,15 @@
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/debug-utils "2.9.0"]
-                 [org.cyverse/clojure-commons "3.0.11"]
+                 [org.cyverse/clojure-commons "3.0.12"]
                  [org.cyverse/common-cli "2.8.2"]
                  [me.raynes/fs "1.4.6"]
-                 [cheshire "6.1.0"]
+                 [cheshire "6.2.0"]
                  [slingshot "0.12.2"]
                  [compojure "1.7.2" :exclusions [ring/ring-codec]]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
-                 [ring/ring-core "1.15.3"]
-                 [ring/ring-jetty-adapter "1.15.3"]]
+                 [ring/ring-core "1.15.4"]
+                 [ring/ring-jetty-adapter "1.15.4"]]
 
   :eastwood {:exclude-namespaces [:test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}


### PR DESCRIPTION
Bump Clojure deps: clojure 1.12.5, logback-classic 1.5.32, clojure-commons 3.0.12, cheshire 6.2.0, ring 1.15.4.

Bump npm: relax less to ~4.6 (now 4.6.4) and refresh lockfile to pick up grunt 1.6.2.